### PR TITLE
feat: Add room duration and room peak user count prometheus metric

### DIFF
--- a/lib/signal_tower/prometheus_stats.ex
+++ b/lib/signal_tower/prometheus_stats.ex
@@ -4,20 +4,41 @@ defmodule SignalTower.PrometheusStats do
   @counter [name: :palava_room_closed_total, labels: [], help: "Number of rooms closed"]
   @counter [name: :palava_joined_room_total, labels: [], help: "Number of peers joined a room"]
   @counter [name: :palava_leave_room_total, labels: [], help: "Number of peers left a room"]
+  @histogram [
+    name: :palava_duration_room_milliseconds,
+    labels: [],
+    buckets: Prometheus.Buckets.new({:exponential, 1000, 2, 20}),
+    help: "Room duration in milliseconds"
+  ]
+  @histogram [
+    name: :palava_room_peak_users_total,
+    labels: [],
+    buckets: Prometheus.Buckets.new({:linear, 1, 1, 10}),
+    help: "Room peak user count"
+  ]
 
   def reset() do
     Counter.reset(name: :palava_room_created_total)
     Counter.reset(name: :palava_room_closed_total)
     Counter.reset(name: :palava_joined_room_total)
     Counter.reset(name: :palava_leave_room_total)
+    Histogram.reset(name: :palava_duration_room_milliseconds)
+    Histogram.reset(name: :palava_room_peak_users_total)
   end
 
   def room_created() do
     Counter.inc(name: :palava_room_created_total)
   end
 
-  def room_closed() do
+  def room_closed(duration, peak_user_count) do
     Counter.inc(name: :palava_room_closed_total)
+
+    Histogram.observe(
+      [name: :palava_duration_room_milliseconds, labels: []],
+      duration * 1_000_000
+    )
+
+    Histogram.observe([name: :palava_room_peak_users_total, labels: []], peak_user_count)
   end
 
   def join() do

--- a/lib/signal_tower/prometheus_stats.ex
+++ b/lib/signal_tower/prometheus_stats.ex
@@ -7,6 +7,7 @@ defmodule SignalTower.PrometheusStats do
   @histogram [
     name: :palava_duration_room_milliseconds,
     labels: [],
+    # Creates 20 buckets {1000, 2000, 4000, 8000, 16000, ...}
     buckets: Prometheus.Buckets.new({:exponential, 1000, 2, 20}),
     help: "Room duration in milliseconds"
   ]

--- a/lib/signal_tower/room.ex
+++ b/lib/signal_tower/room.ex
@@ -3,7 +3,6 @@ defmodule SignalTower.Room do
 
   alias SignalTower.Room.{Member, Membership, Supervisor}
   alias SignalTower.Stats
-  alias SignalTower.PrometheusStats
 
   ## API ##
 
@@ -23,18 +22,16 @@ defmodule SignalTower.Room do
 
   def init(room_id) do
     GenServer.cast(Stats, {:room_created, self()})
-    SignalTower.PrometheusStats.room_created()
     {:ok, {room_id, %{}}}
   end
 
   def handle_call({:join, pid, status}, _, {room_id, members}) do
-    GenServer.cast(Stats, {:update_room_peak, self(), map_size(members) + 1})
+    GenServer.cast(Stats, {:peer_joined, self(), map_size(members) + 1})
 
     Process.monitor(pid)
     peer_id = UUID.uuid1()
     send_joined_room(pid, peer_id, members)
     send_new_peer(members, peer_id, status)
-    PrometheusStats.join()
 
     new_member = %Member{peer_id: peer_id, pid: pid, status: status}
     {:reply, peer_id, {room_id, Map.put(members, peer_id, new_member)}}
@@ -95,14 +92,14 @@ defmodule SignalTower.Room do
 
   defp leave(peer_id, state = {room_id, members}) do
     if members[peer_id] do
-      PrometheusStats.leave()
+      GenServer.cast(Stats, {:peer_left, self()})
       next_members = Map.delete(members, peer_id)
 
       if map_size(next_members) > 0 do
         send_peer_left(next_members, peer_id)
         {:ok, {room_id, next_members}}
       else
-        SignalTower.PrometheusStats.room_closed()
+        GenServer.cast(Stats, {:room_closed, self()})
         {:stop, {room_id, next_members}}
       end
     else

--- a/lib/signal_tower/stats.ex
+++ b/lib/signal_tower/stats.ex
@@ -1,15 +1,14 @@
 defmodule SignalTower.Stats do
   alias SignalTower.Stats.RoomSession
+  alias SignalTower.PrometheusStats
   use GenServer
 
   ## API ##
-
   def start_link(log_file) do
     GenServer.start_link(__MODULE__, log_file, name: __MODULE__)
   end
 
   ## Callbacks ##
-
   def init(log_file) do
     file = File.open!(log_file, [:write, :append])
     {:ok, {file, %{}}}
@@ -19,10 +18,27 @@ defmodule SignalTower.Stats do
     Process.monitor(pid)
     time = DateTime.utc_now()
     new_session = %RoomSession{pid: pid, create_time: time, peak_time: time}
+    PrometheusStats.room_created()
     {:noreply, {file, Map.put(room_sessions, pid, new_session)}}
   end
 
-  def handle_cast({:update_room_peak, pid, count}, {file, room_sessions}) do
+  def handle_cast({:room_closed, pid}, state = {_file, room_sessions}) do
+    case Map.pop(room_sessions, pid) do
+      {nil, _} ->
+        {:noreply, state}
+
+      {room_session, _} ->
+        room_session_duration =
+          DateTime.diff(DateTime.utc_now(), room_session.create_time, :millisecond)
+
+        PrometheusStats.room_closed(room_session_duration, room_session.peak_user_count)
+        {:noreply, state}
+    end
+  end
+
+  def handle_cast({:peer_joined, pid, count}, {file, room_sessions}) do
+    SignalTower.PrometheusStats.join()
+
     if room_sessions[pid] && room_sessions[pid].peak_user_count < count do
       updated_room_sessions =
         room_sessions
@@ -35,25 +51,12 @@ defmodule SignalTower.Stats do
     end
   end
 
-  def handle_info({:DOWN, _ref, _, pid, _}, state = {file, room_sessions}) do
-    case Map.pop(room_sessions, pid) do
-      {nil, _} ->
-        {:noreply, state}
+  def handle_cast({:peer_left, _pid}, state) do
+    PrometheusStats.leave()
+    {:noreply, state}
+  end
 
-      {s, updated_room_sessions} ->
-        log_line =
-          Enum.join(
-            [
-              s.create_time |> DateTime.to_string(),
-              s.peak_time |> DateTime.to_string(),
-              DateTime.utc_now() |> DateTime.to_string(),
-              s.peak_user_count
-            ],
-            ","
-          )
-
-        IO.binwrite(file, log_line <> "\n")
-        {:noreply, {file, updated_room_sessions}}
-    end
+  def handle_info({:DOWN, _ref, _, _pid, _}, state = {_file, _room_sessions}) do
+    {:noreply, state}
   end
 end

--- a/lib/signal_tower/stats.ex
+++ b/lib/signal_tower/stats.ex
@@ -15,7 +15,6 @@ defmodule SignalTower.Stats do
   end
 
   def handle_cast({:room_created, pid}, {file, room_sessions}) do
-    Process.monitor(pid)
     time = DateTime.utc_now()
     new_session = %RoomSession{pid: pid, create_time: time, peak_time: time}
     PrometheusStats.room_created()
@@ -37,7 +36,7 @@ defmodule SignalTower.Stats do
   end
 
   def handle_cast({:peer_joined, pid, count}, {file, room_sessions}) do
-    SignalTower.PrometheusStats.join()
+    PrometheusStats.join()
 
     if room_sessions[pid] && room_sessions[pid].peak_user_count < count do
       updated_room_sessions =
@@ -53,10 +52,6 @@ defmodule SignalTower.Stats do
 
   def handle_cast({:peer_left, _pid}, state) do
     PrometheusStats.leave()
-    {:noreply, state}
-  end
-
-  def handle_info({:DOWN, _ref, _, _pid, _}, state = {_file, _room_sessions}) do
     {:noreply, state}
   end
 end

--- a/test/prometheus_stats_test.exs
+++ b/test/prometheus_stats_test.exs
@@ -4,28 +4,21 @@ defmodule PrometheusStatsTest do
   alias SignalTower.PrometheusStats
 
   test "should return text formated metrics" do
-    assert(String.match?(PrometheusStats.to_string(), ~r/palava_room_created_total/))
-    assert(String.match?(PrometheusStats.to_string(), ~r/palava_room_closed_total/))
-    assert(String.match?(PrometheusStats.to_string(), ~r/palava_joined_room_total/))
-    assert(String.match?(PrometheusStats.to_string(), ~r/palava_leave_room_total/))
-
-    assert(
-      String.match?(PrometheusStats.to_string(), ~r/palava_duration_room_milliseconds_bucket/)
-    )
-
-    assert(
-      String.match?(PrometheusStats.to_string(), ~r/palava_duration_room_milliseconds_count/)
-    )
-
-    assert(String.match?(PrometheusStats.to_string(), ~r/palava_duration_room_milliseconds_sum/))
-    assert(String.match?(PrometheusStats.to_string(), ~r/palava_room_peak_users_total_bucket/))
-    assert(String.match?(PrometheusStats.to_string(), ~r/palava_room_peak_users_total_count/))
-    assert(String.match?(PrometheusStats.to_string(), ~r/palava_room_peak_users_total_sum/))
+    assert(String.match?(get_stats(), ~r/palava_room_created_total/))
+    assert(String.match?(get_stats(), ~r/palava_room_closed_total/))
+    assert(String.match?(get_stats(), ~r/palava_joined_room_total/))
+    assert(String.match?(get_stats(), ~r/palava_leave_room_total/))
+    assert(String.match?(get_stats(), ~r/palava_duration_room_milliseconds_bucket/))
+    assert(String.match?(get_stats(), ~r/palava_duration_room_milliseconds_count/))
+    assert(String.match?(get_stats(), ~r/palava_duration_room_milliseconds_sum/))
+    assert(String.match?(get_stats(), ~r/palava_room_peak_users_total_bucket/))
+    assert(String.match?(get_stats(), ~r/palava_room_peak_users_total_count/))
+    assert(String.match?(get_stats(), ~r/palava_room_peak_users_total_sum/))
   end
 
   test "should reset metrics" do
     PrometheusStats.reset()
-    metric_map = to_map(PrometheusStats.to_string())
+    metric_map = to_map(get_stats())
     assert("0" == metric_map["palava_room_created_total"])
     assert("0" == metric_map["palava_room_closed_total"])
     assert("0" == metric_map["palava_joined_room_total"])
@@ -39,42 +32,42 @@ defmodule PrometheusStatsTest do
   test "should increment on room created" do
     PrometheusStats.reset()
     PrometheusStats.room_created()
-    metric_map = to_map(PrometheusStats.to_string())
+    metric_map = to_map(get_stats())
     assert("1" == metric_map["palava_room_created_total"])
   end
 
   test "should increment on room closed" do
     PrometheusStats.reset()
     PrometheusStats.room_closed(0, 0)
-    metric_map = to_map(PrometheusStats.to_string())
+    metric_map = to_map(get_stats())
     assert("1" == metric_map["palava_room_closed_total"])
   end
 
   test "should observe session duratoin on room closed" do
     PrometheusStats.reset()
     PrometheusStats.room_closed(1, 0)
-    metric_map = to_map(PrometheusStats.to_string())
+    metric_map = to_map(get_stats())
     assert("1.0" == metric_map["palava_duration_room_milliseconds_sum"])
   end
 
   test "should observe peak user count on room closed" do
     PrometheusStats.reset()
     PrometheusStats.room_closed(0, 5)
-    metric_map = to_map(PrometheusStats.to_string())
+    metric_map = to_map(get_stats())
     assert("5" == metric_map["palava_room_peak_users_total_sum"])
   end
 
   test "should increment on join" do
     PrometheusStats.reset()
     PrometheusStats.join()
-    metric_map = to_map(PrometheusStats.to_string())
+    metric_map = to_map(get_stats())
     assert "1" == metric_map["palava_joined_room_total"]
   end
 
   test "should increment on leave" do
     PrometheusStats.reset()
     PrometheusStats.leave()
-    metric_map = to_map(PrometheusStats.to_string())
+    metric_map = to_map(get_stats())
     assert "1" == metric_map["palava_leave_room_total"]
   end
 
@@ -85,5 +78,9 @@ defmodule PrometheusStatsTest do
     |> Enum.reject(&(&1 == ""))
     |> Enum.map(&String.split(&1, " "))
     |> Map.new(&List.to_tuple/1)
+  end
+
+  defp get_stats() do
+    PrometheusStats.to_string()
   end
 end


### PR DESCRIPTION
I added the room duration and room peak user count to the prometheus metric module. The module is now wired through the stats module.