### PR TITLE
Respond to client side websocket pings

### DIFF
--- a/lib/signal_tower/msg_integrity.ex
+++ b/lib/signal_tower/msg_integrity.ex
@@ -40,6 +40,10 @@ defmodule SignalTower.MsgIntegrity do
     is_map(msg["status"])
   end
 
+  defp complete?("ping", _msg) do
+    true
+  end
+
   defp check_room_event(room, event) do
     if room || !Enum.member?(@room_messages, event) do
       if valid_room_event?(room, event) do

--- a/lib/signal_tower/session.ex
+++ b/lib/signal_tower/session.ex
@@ -48,6 +48,18 @@ defmodule SignalTower.Session do
     room
   end
 
+  defp incoming_message(%{"event" => "ping"}, room) do
+    send(
+      self(),
+      {:to_user,
+       %{
+         event: "pong"
+       }}
+    )
+
+    room
+  end
+
   # invoked when a room exits
   def handle_exit_message(pid, room, status) do
     if room && pid == room.pid && status != :normal do

--- a/test/session_test.exs
+++ b/test/session_test.exs
@@ -177,6 +177,17 @@ defmodule SessionTest do
     wait_for_breaks(1)
   end
 
+  test "respond to client ping" do
+    Session.handle_message(
+      %{
+        "event" => "ping"
+      },
+      nil
+    )
+
+    assert_receive {:to_user, %{event: "pong"}}
+  end
+
   defp create_client(room_id \\ nil, leave_after_finish \\ false, fun) do
     host = self()
 


### PR DESCRIPTION
The signaltower already uses the implicit websocket pings to keep track of
the websocket liveliness. The client can't trigger the implicit pings though,
so we're answering to explicit ping messages.