### PR TITLE
Add deps and build cache for CI runs

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -20,13 +19,32 @@ jobs:
         otp-version: 22.2 # Define the OTP version [required]
     - name: Check formatting
       run: mix format --check-formatted
+
+    - name: Cache Dependencies
+      id: mix-cache
+      uses: actions/cache@v2
+      with:
+        path: deps
+        key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
     - name: Install Dependencies
+      if: steps.mix-cache.outputs.cache-hit != 'true'
       run: mix deps.get
+
+    - name: Cache Build
+      id: build-cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          _build
+          !_build/*/lib/signal_tower
+        key: ${{ runner.os }}-mix-${{ hashFiles(format('{0}{1}', github.workspace, '/mix.lock')) }}
     - name: Compile Dependencies
       run: mix deps.compile
     - name: Compile and check for warnings
       run: mix compile --warnings-as-errors
+
     - name: Run Tests
       run: mix test
+
     - name: Run dialyzer static code analysis
       run: mix dialyzer


### PR DESCRIPTION
Fixes #19 

* Caches dependencies and dependency builds (excluding the signal_tower files)
* Dialyzer picks up existing PLT files (which are written to `_build/dev/`), which are cached in the build cache step
* Caches are invalidated by changes in the `mix.lock` file.
* Brings down the CI run time from >10 min to ~33 sec (see test PR and last action runs in https://github.com/paulgoetze/signaltower/actions)