### PR TITLE
Add TURN support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,19 @@ mix test.watch
 mix release production
 ```
 
+**Options:**
+
+To use a Turn Server, generate a secret key string, e.g. via `openssl rand -base64 30` and set:
+```
+export SIGNALTOWER_TURN_SECRET=<generated_secret_key>
+```
+The same secret key must be configured in the turn server.
+For example for coturn, use the following configuration in turnserver.conf:
+```
+use-auth-secret
+static-auth-secret=<generated_secret_key>
+```
+
 By default, the websocket port 4233 is used, you can change it via:
 ```
 export SIGNALTOWER_PORT=1234
@@ -46,6 +59,8 @@ By default, the websocket is bound to all interfaces (0.0.0.0), you can also bin
 ```
 export SIGNALTOWER_LOCALHOST
 ```
+
+## References
 
 [palava protocol]: https://github.com/palavatv/palava-client/wiki/Protocol
 [palava client]: https://github.com/palavatv/palava-client/

--- a/lib/signal_tower/session.ex
+++ b/lib/signal_tower/session.ex
@@ -11,10 +11,10 @@ defmodule SignalTower.Session do
     |> (&Process.register(self(), &1)).()
   end
 
-  def handle_message(msg, room) do
+  def handle_message(msg, {room, ltt}) do
     case MsgIntegrity.check(msg, room) do
       {:ok, msg} ->
-        incoming_message(msg, room)
+        incoming_message(msg, {room, ltt})
 
       {:error, error} ->
         send_error(error, msg)
@@ -22,37 +22,37 @@ defmodule SignalTower.Session do
     end
   end
 
-  defp incoming_message(msg = %{"event" => "join_room"}, _) do
-    Room.join_and_monitor(msg["room_id"], msg["status"])
+  defp incoming_message(msg = %{"event" => "join_room"}, {_, last_turn_timestamp}) do
+    Room.join_and_monitor(msg["room_id"], msg["status"], last_turn_timestamp)
   end
 
-  defp incoming_message(msg = %{"event" => "leave_room"}, room) do
+  defp incoming_message(msg = %{"event" => "leave_room"}, {room, ltt}) do
     if room do
       case GenServer.call(room.pid, {:leave, room.own_id}) do
         :ok ->
-          nil
+          {nil, ltt}
 
         :error ->
           send_error("You are not currently in a room, so you can not leave it", msg)
-          room
+          {room, ltt}
       end
     else
       send_error("You are not currently in a room, so you can not leave it", msg)
-      room
+      {room, ltt}
     end
   end
 
-  defp incoming_message(msg = %{"event" => "send_to_peer"}, room) do
+  defp incoming_message(msg = %{"event" => "send_to_peer"}, {room, ltt}) do
     GenServer.cast(room.pid, {:send_to_peer, msg["peer_id"], msg["data"], room.own_id})
-    room
+    {room, ltt}
   end
 
-  defp incoming_message(msg = %{"event" => "update_status"}, room) do
+  defp incoming_message(msg = %{"event" => "update_status"}, {room, ltt}) do
     GenServer.cast(room.pid, {:update_status, room.own_id, msg["status"]})
-    room
+    {room, ltt}
   end
 
-  defp incoming_message(%{"event" => "ping"}, room) do
+  defp incoming_message(%{"event" => "ping"}, state) do
     send(
       self(),
       {:to_user,
@@ -61,16 +61,16 @@ defmodule SignalTower.Session do
        }}
     )
 
-    room
+    state
   end
 
   # invoked when a room exits
-  def handle_exit_message(pid, room, status) do
+  def handle_exit_message(pid, room, status, ltt) do
     if room && pid == room.pid && status != :normal do
       # current room died => automatic rejoin
-      Room.join_and_monitor(room.id, room.own_status)
+      Room.join_and_monitor(room.id, room.own_status, ltt)
     else
-      nil
+      {nil, ltt}
     end
   end
 

--- a/lib/signal_tower/session.ex
+++ b/lib/signal_tower/session.ex
@@ -23,7 +23,7 @@ defmodule SignalTower.Session do
   end
 
   defp incoming_message(msg = %{"event" => "join_room"}, state) do
-    Room.join_and_monitor(msg["room_id"], msg["status"], state.turn_timeout)
+    Room.join_and_monitor(msg["room_id"], msg["status"], state.turn_token_expiry)
   end
 
   defp incoming_message(msg = %{"event" => "leave_room"}, state = %{room: room}) do
@@ -65,10 +65,14 @@ defmodule SignalTower.Session do
   end
 
   # invoked when a room exits
-  def handle_exit_message(pid, status, state = %{room: room, turn_timeout: turn_timeout}) do
+  def handle_exit_message(
+        pid,
+        status,
+        state = %{room: room, turn_token_expiry: turn_token_expiry}
+      ) do
     if room && pid == room.pid && status != :normal do
       # current room died => automatic rejoin
-      Room.join_and_monitor(room.id, room.own_status, turn_timeout)
+      Room.join_and_monitor(room.id, room.own_status, turn_token_expiry)
     else
       state
     end

--- a/lib/signal_tower/websocket_handler.ex
+++ b/lib/signal_tower/websocket_handler.ex
@@ -9,8 +9,8 @@ defmodule SignalTower.WebsocketHandler do
     initial_state = %{
       # room membership
       room: nil,
-      # initialize turn timeout with 0, it will be properly initialized on first room join
-      turn_timeout: 0
+      # initialize turn token expiry with 0, it will be properly initialized on first room join
+      turn_token_expiry: 0
     }
 
     {:cowboy_websocket, req, initial_state, %{idle_timeout: :timer.seconds(30)}}

--- a/test/room_test.exs
+++ b/test/room_test.exs
@@ -23,7 +23,7 @@ defmodule RoomTest do
 
     _user2 =
       spawn_user_no_join(fn ->
-        GenServer.call(room_pid, {:join, self(), %{user: "1"}})
+        GenServer.call(room_pid, {:join, self(), %{user: "1"}, 0})
 
         assert_receive {:to_user,
                         %{
@@ -39,8 +39,54 @@ defmodule RoomTest do
     wait_for_breaks(2)
   end
 
-  test "send to peer" do
+  test "join room with turn" do
+    System.put_env("SIGNALTOWER_TURN_SECRET", "verysecretpassphrase1234")
     room_pid = create_room("r-room3")
+
+    go = fn timestamp_before ->
+      spawn_user_no_join(fn ->
+        GenServer.call(room_pid, {:join, self(), %{user: "1"}, 0})
+
+        assert_receive(
+          {:to_user,
+           %{
+             event: "joined_room",
+             own_id: own_id,
+             turn_user: user,
+             turn_password: pw
+           }},
+          1000
+        )
+
+        [timestamp_str, id] = String.split(user, ":")
+        {timestamp, ""} = Integer.parse(timestamp_str)
+        assert own_id == id
+        assert System.os_time(:second) < timestamp
+        assert timestamp < System.os_time(:second) + 3 * 60 * 60 + 10
+        assert timestamp_before <= timestamp
+
+        assert pw ==
+                 :crypto.mac(
+                   :hmac,
+                   :sha,
+                   to_charlist("verysecretpassphrase1234"),
+                   to_charlist(user)
+                 )
+                 |> Base.encode64()
+      end)
+    end
+
+    go.(0)
+    # is depleted
+    go.(System.os_time(:second) - 200)
+    # is still valid
+    go.(System.os_time(:second) + 200)
+
+    wait_for_breaks(2)
+  end
+
+  test "send to peer" do
+    room_pid = create_room("r-room4")
 
     user1 =
       spawn_user(room_pid, fn own_id ->
@@ -67,7 +113,7 @@ defmodule RoomTest do
   end
 
   test "update status" do
-    room_pid = create_room("r-room4")
+    room_pid = create_room("r-room5")
     join_room(self(), room_pid)
 
     spawn_user(room_pid, fn own_id ->
@@ -87,7 +133,7 @@ defmodule RoomTest do
   end
 
   test "leave room" do
-    room_pid = create_room("r-room5")
+    room_pid = create_room("r-room6")
     join_room(self(), room_pid)
 
     spawn_user(room_pid, fn own_id ->
@@ -108,7 +154,7 @@ defmodule RoomTest do
 
   # session process dies
   test "user leaves room when his session dies" do
-    room_pid = create_room("r-room6")
+    room_pid = create_room("r-room7")
     join_room(self(), room_pid)
 
     spawn_link(fn ->
@@ -128,7 +174,7 @@ defmodule RoomTest do
   end
 
   test "room exits when last active user is gone" do
-    room_pid = create_room("r-room7")
+    room_pid = create_room("r-room8")
     Process.monitor(room_pid)
     own_id = join_room(self(), room_pid)
     GenServer.call(room_pid, {:leave, own_id})
@@ -140,7 +186,7 @@ defmodule RoomTest do
   end
 
   defp join_room(pid, room_pid) do
-    GenServer.call(room_pid, {:join, pid, %{standard: "status"}})
+    GenServer.call(room_pid, {:join, pid, %{standard: "status"}, 0})
     assert_receive {:to_user, %{event: "joined_room", own_id: own_id}}, 1000
     own_id
   end

--- a/test/session_test.exs
+++ b/test/session_test.exs
@@ -15,7 +15,7 @@ defmodule SessionTest do
             "room_id" => "s-room1",
             "status" => %{user: "0"}
           },
-          nil
+          {nil, 0}
         )
 
         assert_receive {:to_user,
@@ -54,7 +54,7 @@ defmodule SessionTest do
             "room_id" => "s-room1",
             "status" => %{user: "1"}
           },
-          nil
+          {nil, 0}
         )
 
         assert_receive {:to_user,
@@ -77,7 +77,7 @@ defmodule SessionTest do
             "event" => "leave_room",
             "room_id" => "s-room13"
           },
-          room
+          {room, 0}
         )
       end)
 
@@ -100,7 +100,7 @@ defmodule SessionTest do
                 "peer_id" => peer_id,
                 "data" => %{some: "data"}
               },
-              room
+              {room, 0}
             )
         end
       end)
@@ -128,7 +128,7 @@ defmodule SessionTest do
             "event" => "update_status",
             "status" => %{some: "status"}
           },
-          room
+          {room, 0}
         )
       end)
 
@@ -155,7 +155,7 @@ defmodule SessionTest do
               "event" => "update_status",
               "status" => %{new: "status"}
             },
-            nil
+            {nil, 0}
           )
 
         assert_receive {:to_user, m = %{event: "error"}}
@@ -167,7 +167,7 @@ defmodule SessionTest do
             "peer_id" => "some_peer",
             "data" => %{some: "data"}
           },
-          room
+          {room, 0}
         )
 
         assert_receive {:to_user, m = %{event: "error"}}
@@ -182,7 +182,7 @@ defmodule SessionTest do
       %{
         "event" => "ping"
       },
-      nil
+      {nil, 0}
     )
 
     assert_receive {:to_user, %{event: "pong"}}
@@ -193,7 +193,7 @@ defmodule SessionTest do
       %{
         "event" => "unknown"
       },
-      nil
+      {nil, 0}
     )
 
     assert_receive {:to_user, %{event: "error"}}
@@ -224,14 +224,14 @@ defmodule SessionTest do
   end
 
   defp join_room(room_id, host) do
-    room =
+    {room, _} =
       Session.handle_message(
         %{
           "event" => "join_room",
           "room_id" => room_id,
           "status" => %{local: "status"}
         },
-        nil
+        {nil, 0}
       )
 
     if host, do: send(host, :start)

--- a/test/session_test.exs
+++ b/test/session_test.exs
@@ -4,7 +4,7 @@ defmodule SessionTest do
 
   alias SignalTower.Session
 
-  @initial_state %{room: nil, turn_timeout: 0}
+  @initial_state %{room: nil, turn_token_expiry: 0}
 
   test "join and leave with registered users" do
     host_pid = self()
@@ -79,7 +79,7 @@ defmodule SessionTest do
             "event" => "leave_room",
             "room_id" => "s-room13"
           },
-          %{room: room, turn_timeout: 0}
+          %{room: room, turn_token_expiry: 0}
         )
       end)
 
@@ -102,7 +102,7 @@ defmodule SessionTest do
                 "peer_id" => peer_id,
                 "data" => %{some: "data"}
               },
-              %{room: room, turn_timeout: 0}
+              %{room: room, turn_token_expiry: 0}
             )
         end
       end)
@@ -130,7 +130,7 @@ defmodule SessionTest do
             "event" => "update_status",
             "status" => %{some: "status"}
           },
-          %{room: room, turn_timeout: 0}
+          %{room: room, turn_token_expiry: 0}
         )
       end)
 
@@ -169,7 +169,7 @@ defmodule SessionTest do
             "peer_id" => "some_peer",
             "data" => %{some: "data"}
           },
-          %{room: room, turn_timeout: 0}
+          %{room: room, turn_token_expiry: 0}
         )
 
         assert_receive {:to_user, m = %{event: "error"}}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,4 +6,33 @@ defmodule TestHelper do
   def wait_for_breaks(n) when n > 0 do
     1..n |> Enum.each(fn _ -> assert_receive :break, 10_000 end)
   end
+
+  def receive_and_check_turn_credentials(expiry_before) do
+    assert_receive(
+      {:to_user,
+       %{
+         event: "joined_room",
+         own_id: own_id,
+         turn_user: user,
+         turn_password: pw
+       }},
+      1000
+    )
+
+    [expiry_str, id] = String.split(user, ":")
+    expiry = String.to_integer(expiry_str)
+    assert own_id == id
+    assert System.os_time(:second) < expiry
+    assert expiry < System.os_time(:second) + 3 * 60 * 60 + 10
+    assert expiry_before <= expiry
+
+    assert pw ==
+             :crypto.mac(
+               :hmac,
+               :sha,
+               to_charlist("verysecretpassphrase1234"),
+               to_charlist(user)
+             )
+             |> Base.encode64()
+  end
 end


### PR DESCRIPTION
If SIGNALTOWER_TURN_SECRET is set, the signaltower add to each
joined_room message a turn_user and turn_password field that allows the
client to use the TURN server for 3 hours. In the following 3h, the
client will always get the same login/token with the same end time back
when it joins another room.