### PR TITLE
Fix depcrecation warning: import Config instead of use Mix.Config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 if Mix.env() == :dev do
   config :mix_test_watch,


### PR DESCRIPTION
Fixes the deprecation warning during compilation: 

```
warning: use Mix.Config is deprecated. Use the Config module instead
```